### PR TITLE
Add Support for Privacy Function URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ has already been initialized, use `PlayerZero.isInitialized()`.
 
 ### PlayerZero API
 
-* `PlayerZero.init(projectId: string, options: {endpoint?: string, privacyFnUrl?: string})` - Initialize PlayerZero with
-  your Project ID and optional configuration. The project id can be found on [PlayerZero's](https://playerzero.ai)
+* `PlayerZero.init(apiToken: string, options: {endpoint?: string, privacyFnUrl?: string})` - Initialize PlayerZero with
+  your API Token and optional configuration. The API Token can be found on [PlayerZero's](https://playerzero.ai)
   `Project Settings` under the `Web SDK` area.
 * `PlayerZero.isInitialized(): Boolean` - Returns `true` if PlayerZero is initialized.
 * `PlayerZero.identify(userId: string, metadata: Record<string, unknown>)` - Identify the current user and associate

--- a/README.md
+++ b/README.md
@@ -1,36 +1,48 @@
 # PlayerZero Web SDK
-PlayerZero's browser SDK lets you manage PlayerZero on your site as well as 
-generate links to devtools and send your own custom events. More information about the PlayerZero API can be found at https://docs.playerzero.app.
+
+PlayerZero's browser SDK lets you manage PlayerZero on your site as well as
+generate links to devtools and send your own custom events. More information about the PlayerZero API can be found
+at https://docs.playerzero.app.
 
 ## Install the SDK
+
 **with npm**
+
 ```shell
 npm i @goplayerzero/sdk-web --save
 ```
 
 **with yarn**
+
 ```shell
 yarn add @goplayerzero/sdk-web
 ```
 
 ## Initialize the SDK
-Call the `init()` function with your Project ID as soon as you can in your website startup process. 
-Calling init a second time after successful initialization will trigger console warnings - 
-if you need to programmatically check if PlayerZero has been initialized at some point in your code, you can call `PlayerZero.isInitialized()`.
+
+Call the `init()` function with your Project ID as soon as you can in your website startup process.
+Calling init a second time after successful initialization will trigger console warnings -
+if you need to programmatically check if PlayerZero has been initialized at some point in your code, you can call
+`PlayerZero.isInitialized()`.
 
 ### PlayerZero API
-* `PlayerZero.init(projectId: string)` - Initialize PlayerZero on your site with the specific Project ID. The project id can be found on the [Settings > Data Collection page](https://go.playerzero.app/setting/data)
+
+* `PlayerZero.init(projectId: string | {endpoint?: string, privacyFnUrl?: string})` - Initialize PlayerZero on your site
+  with the specific Project ID. The project id can be found on
+  the [Settings > Data Collection page](https://go.playerzero.app/setting/data)
 * `PlayerZero.isInitialized(): Boolean` - Check if PlayerZero is initialized in your application.
 * `PlayerZero.identify(userId: string, metadata: Record<string, unknown>)` - Identify your user with PlayerZero
-* `PlayerZero.setUserVars(metadata: Record<string, unknown>)` - Set user properties & metadata without resetting the identity
+* `PlayerZero.setUserVars(metadata: Record<string, unknown>)` - Set user properties & metadata without resetting the
+  identity
 * `PlayerZero.track(event: string, metadata?: Record<string, unknown>)` - Send an analytics event to PlayerZero
 * `PlayerZero.prompt()` - Prompt the user to upload their Devtools Report
 * `PlayerZero.devtoolsUrl(): Promise<string>` - Generate a Devtools URL for the current session
-* `PlayerZero.kill()` - Shut down PlayerZero immediately. PlayerZero cannot be reinitialized after this is called. 
+* `PlayerZero.kill()` - Shut down PlayerZero immediately. PlayerZero cannot be reinitialized after this is called.
 
-### Examples 
+### Examples
 
 #### React
+
 ```javascript
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -40,10 +52,11 @@ import PlayerZero from '@goplayerzero/sdk-web';
 
 PlayerZero.init('<your project id here>');
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(<App/>, document.getElementById('root'));
 ```
 
 #### Angular - `main.ts`
+
 ```javascript
 import { Component } from '@angular/core';
 import PlayerZero from '@goplayerzero/sdk-web';
@@ -63,6 +76,7 @@ export class AppComponent {
 ```
 
 #### Vue
+
 ```javascript
 import Vue from 'vue';
 import App from './App.vue';
@@ -77,6 +91,7 @@ new Vue({
 ```
 
 #### Vue 3
+
 ```javascript
 import { createApp } from 'vue'
 import App from './App.vue'
@@ -90,9 +105,11 @@ app.mount('#app');
 ```
 
 ## Using the SDK
+
 Once PlayerZero is initialized, you can make calls to the PlayerZero SDK.
 
 ### Identify a User
+
 ```javascript
 PlayerZero.identify(
   'userId',
@@ -105,6 +122,7 @@ PlayerZero.identify(
 ```
 
 ### Track custom analytics events
+
 ```javascript
 PlayerZero.track(
   'checkout',
@@ -113,6 +131,7 @@ PlayerZero.track(
 ```
 
 ### Generate a Devtools URL
+
 ```javascript
 PlayerZero.devtoolsUrl().then(url => console.log('PlayerZero Devtools URL', url));
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # PlayerZero Web SDK
 
-PlayerZero's browser SDK lets you manage PlayerZero on your site as well as
-generate links to devtools and send your own custom events. More information about the PlayerZero API can be found
-at https://docs.playerzero.app.
+The PlayerZero Web SDK enables you to integrate PlayerZero into your website or web application. With this SDK, you can
+manage PlayerZero initialization, identify users, track custom analytics events, generate DevTools links, and more. For
+comprehensive API documentation,
+visit [PlayerZero Docs](https://playerzero.ai/docs/developer-guide/configuration-guides/capturing-user-sessions/npm).
 
-## Install the SDK
+---
 
-**with npm**
+## Installation
+
+Install the SDK using your preferred package manager:
+
+**npm**
 
 ```shell
 npm i @goplayerzero/sdk-web --save
@@ -20,24 +25,24 @@ yarn add @goplayerzero/sdk-web
 
 ## Initialize the SDK
 
-Call the `init()` function with your Project ID as soon as you can in your website startup process.
-Calling init a second time after successful initialization will trigger console warnings -
-if you need to programmatically check if PlayerZero has been initialized at some point in your code, you can call
-`PlayerZero.isInitialized()`.
+Calling `init()` more than once after successful initialization will trigger console warnings. To check if PlayerZero
+has already been initialized, use `PlayerZero.isInitialized()`.
 
 ### PlayerZero API
 
-* `PlayerZero.init(projectId: string | {endpoint?: string, privacyFnUrl?: string})` - Initialize PlayerZero on your site
-  with the specific Project ID. The project id can be found on
-  the [Settings > Data Collection page](https://go.playerzero.app/setting/data)
-* `PlayerZero.isInitialized(): Boolean` - Check if PlayerZero is initialized in your application.
-* `PlayerZero.identify(userId: string, metadata: Record<string, unknown>)` - Identify your user with PlayerZero
-* `PlayerZero.setUserVars(metadata: Record<string, unknown>)` - Set user properties & metadata without resetting the
-  identity
-* `PlayerZero.track(event: string, metadata?: Record<string, unknown>)` - Send an analytics event to PlayerZero
-* `PlayerZero.prompt()` - Prompt the user to upload their Devtools Report
-* `PlayerZero.devtoolsUrl(): Promise<string>` - Generate a Devtools URL for the current session
-* `PlayerZero.kill()` - Shut down PlayerZero immediately. PlayerZero cannot be reinitialized after this is called.
+* `PlayerZero.init(projectId: string, options: {endpoint?: string, privacyFnUrl?: string})` - Initialize PlayerZero with
+  your Project ID and optional configuration. The project id can be found on [PlayerZero's](https://playerzero.ai)
+  `Project Settings` under the `Web SDK` area.
+* `PlayerZero.isInitialized(): Boolean` - Returns `true` if PlayerZero is initialized.
+* `PlayerZero.identify(userId: string, metadata: Record<string, unknown>)` - Identify the current user and associate
+  metadata.
+* `PlayerZero.setUserVars(metadata: Record<string, unknown>)` - Update user properties and metadata without resetting
+  the identity.
+* `PlayerZero.track(event: string, metadata?: Record<string, unknown>)` - Track a custom analytics event with optional
+  metadata.
+* `PlayerZero.prompt()` - Prompt the user to interact with their DevTools report.
+* `PlayerZero.devtoolsUrl(): Promise<string>` - Generate a DevTools URL for the current session.
+* `PlayerZero.kill()` - Immediately shut down PlayerZero. This action is irreversible for the session.
 
 ### Examples
 
@@ -110,6 +115,8 @@ Once PlayerZero is initialized, you can make calls to the PlayerZero SDK.
 
 ### Identify a User
 
+Associate a user and their metadata with PlayerZero:
+
 ```javascript
 PlayerZero.identify(
   'userId',
@@ -123,6 +130,8 @@ PlayerZero.identify(
 
 ### Track custom analytics events
 
+Send custom events to PlayerZero for analytics:
+
 ```javascript
 PlayerZero.track(
   'checkout',
@@ -130,10 +139,20 @@ PlayerZero.track(
 );
 ```
 
-### Generate a Devtools URL
+### Generate a DevTools URL
+
+Create a DevTools URL for the current session:
 
 ```javascript
 PlayerZero.devtoolsUrl().then(url => console.log('PlayerZero Devtools URL', url));
 ```
 
+## Additional Information
 
+* For advanced configuration and troubleshooting, refer to the [official documentation](https://playerzero.ai).
+* If you need to stop PlayerZero during a session, call PlayerZero.kill(). Note that reinitialization is not possible
+  after calling this method.
+
+## Support
+
+For questions or support, please contact [PlayerZero Support](mailto:support@playerzero.ai).

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.0",
+  "version": "0.3.0",
   "name": "@goplayerzero/sdk-web",
   "description": "The official PlayerZero Web SDK",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "0.2.0",
   "name": "@goplayerzero/sdk-web",
   "description": "The official PlayerZero Web SDK",
   "author": {


### PR DESCRIPTION
This PR updates the SDK to support a privacy function URL configuration option. The `init` method now accepts either a project token string or a configuration object that can include an `endpoint` and a `privacyFnUrl`. When provided, the privacy function URL is added as a `data-pz-privacy-src` attribute to the injected script.

The README has been updated to document this new functionality.

Resolves ENG-6137

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/goplayerzero/sdk-web/6)
<!-- Reviewable:end -->